### PR TITLE
Adds an optional metadata to fields

### DIFF
--- a/lib/rails-settings/base.rb
+++ b/lib/rails-settings/base.rb
@@ -29,7 +29,7 @@ module RailsSettings
 
       def field(key, **opts)
         _define_field(key, default: opts[:default], type: opts[:type], readonly: opts[:readonly],
-                           separator: opts[:separator], validates: opts[:validates])
+                           separator: opts[:separator], validates: opts[:validates], metadata: opts[:metadata])
       end
 
       def get_field(key)
@@ -60,7 +60,8 @@ module RailsSettings
 
       private
 
-      def _define_field(key, default: nil, type: :string, readonly: false, separator: nil, validates: nil)
+      def _define_field(key, default: nil, type: :string, readonly: false, separator: nil, validates: nil,
+                        metadata: nil)
         key = key.to_s
 
         @defined_fields ||= []
@@ -68,7 +69,8 @@ module RailsSettings
           key: key,
           default: default,
           type: type || :string,
-          readonly: readonly.nil? ? false : readonly
+          readonly: readonly.nil? ? false : readonly,
+          metadata: metadata
         }
 
         if readonly

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -53,11 +53,14 @@ class BaseTest < ActiveSupport::TestCase
 
   test "get_field" do
     assert_equal({}, Setting.get_field("foooo"))
-    assert_equal({ key: "host", default: "http://example.com", type: :string, readonly: false },
+    assert_equal({
+                   key: "host", default: "http://example.com", type: :string, readonly: false,
+                   metadata: { description: 'Host url' }
+                 },
                  Setting.get_field("host"))
     assert_equal(
       { key: "omniauth_google_options", default: { client_id: "the-client-id", client_secret: "the-client-secret" },
-        type: :hash, readonly: true }, Setting.get_field("omniauth_google_options")
+        type: :hash, readonly: true, metadata: nil }, Setting.get_field("omniauth_google_options")
     )
   end
 
@@ -319,5 +322,9 @@ class BaseTest < ActiveSupport::TestCase
     value = "Ruby Rails,GitHub"
     direct_update_record(:default_tags, value)
     assert_equal %w[Ruby Rails GitHub], Setting.default_tags
+  end
+
+  test "field retains metadata" do
+    assert_equal({ description: "Host url" }, Setting.get_field('host')[:metadata])
   end
 end

--- a/test/models/setting.rb
+++ b/test/models/setting.rb
@@ -3,7 +3,7 @@
 class Setting < RailsSettings::Base
   cache_prefix { "v1" }
 
-  field :host, default: "http://example.com", validates: { presence: true } 
+  field :host, default: "http://example.com", validates: { presence: true }, metadata: { description: "Host url" }
   field :mailer_provider, default: "smtp", validates: { presence: true, inclusion: { in: %w[smtp sendmail sendgrid] } }
   field :readonly_item, type: :integer, default: 100, readonly: true
   field :user_limits, type: :integer, default: 1, validates: { presence: true, format: { with: /[\d]+/, message: "must be numbers" } }


### PR DESCRIPTION
We might need to add certain metadata with each field. This pull request adds this support.

For example, we can add description with different fields, which can be shown on the admin page for updating the fields.

```
field :host, default: "http://example.com", validates: { presence: true }, metadata: { description: "Host url" }
```